### PR TITLE
Fix unintentional global scope variable test for bad_practices exercise

### DIFF
--- a/exercises/bad_practices/exercise.js
+++ b/exercises/bad_practices/exercise.js
@@ -25,11 +25,7 @@ exercise = runFileStreamTests(exercise, function(fileContents, test){
       var regexComment = /\/\//;
       expect(regexComment.test(fileContents)).to.equal(false);
   });
-
-  test('should not have globally scoped variable', function (){
-      var regexVariable = /var /;
-      expect(regexVariable.test(fileContents)).to.equal(false);
-  });
+  
 });
 
 
@@ -40,13 +36,10 @@ exercise = runTests(exercise, function(balanceManager, test){
 
   test('should not have globally scoped variable', function (){
       try {
-          balanceManager.canAfford(null);
+        balanceManager.canAfford(null)
       } catch(e) {}
-      try {
-          balanceManager.canAfford(0.1);
-      } catch(e) {
-        expect(e).to.equal(undefined);
-      }
+      expect(function() { balanceManager.canAfford(0.1) }).to.not.throw(Error);
+      
   });
 });
 

--- a/exercises/bad_practices/exercise.js
+++ b/exercises/bad_practices/exercise.js
@@ -35,11 +35,10 @@ exercise = runTests(exercise, function(balanceManager, test){
   });
 
   test('should not have globally scoped variable', function (){
-      try {
-        balanceManager.canAfford(null)
-      } catch(e) {}
-      expect(function() { balanceManager.canAfford(0.1) }).to.not.throw(Error);
-      
+    try {
+        balanceManager.canAfford(null);
+    } catch(e) {}
+    expect(function() { balanceManager.canAfford(0.1) }).to.not.throw(Error); 
   });
 });
 

--- a/exercises/bad_practices/solution/solution.js
+++ b/exercises/bad_practices/solution/solution.js
@@ -8,8 +8,9 @@ module.exports = {
     return balance;
   },
   canAfford: function(amount){
-    if(this.isValidAmount(amount)){
-        var errorMessage = 'Invalid Input';
+    var errorMessage;
+    if(!this.isValidAmount(amount)){
+        errorMessage = 'Invalid Input';
     }
     if(errorMessage){
         throw new Error(errorMessage);


### PR DESCRIPTION
- Removed redundant test that incorrectly checked for 'var' in the file
- Updated actual test to check that an error message isn't being accidentally set globally when running a function that should exit normally