### PR TITLE
Removed obsolete coinsByAmount from switch excercise

### DIFF
--- a/exercises/switch_statement/solution/solution.js
+++ b/exercises/switch_statement/solution/solution.js
@@ -12,8 +12,6 @@ var coins = {
   'q': 25
 };
 
-var coinsByAmount = ['q', 'd', 'n', 'p'];
-
 module.exports = {
   getAmount: function(coinType) {
     if(!coins.hasOwnProperty(coinType)){


### PR DESCRIPTION
At this step the solution does not use the coinsByAmount variable, yet.